### PR TITLE
Correcting a typo in the examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ resources:
   type: time
   source:
     start: 12:00 AM -0700
-    end: 1:00 AM -0700
+    stop: 1:00 AM -0700
   
 jobs:
 - name: something-after-midnight
@@ -101,7 +101,7 @@ resources:
   source:
     interval: 5m
     start: 12:00 AM -0700
-    end: 1:00 AM -0700
+    stop: 1:00 AM -0700
   
 jobs:
 - name: something-every-5m-during-midnight-hour


### PR DESCRIPTION
The examples incorrectly use `end` instead of `stop` to specify the resource's stop time. This corrects both instances of the problem.