### PR TITLE
Limit time resource to specific days

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ level of precision is better left to other tools.
   stop: 9:00 +0100
   ```
 
+* `days`: *Optional.* Run only on this days. Supported days are: `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` and `Saturday`
+
+  e.g.
+
+  ```
+  days:
+    - Monday
+    - Wednesday
+  ```
+
 These can be combined to emit a new version on an interval during a particular
 time period.
 
@@ -63,7 +73,7 @@ resources:
 - name: 5m
   type: time
   source: {interval: 5m}
-  
+
 jobs:
 - name: something-every-5m
   plan:
@@ -82,7 +92,7 @@ resources:
   source:
     start: 12:00 AM -0700
     stop: 1:00 AM -0700
-  
+
 jobs:
 - name: something-after-midnight
   plan:
@@ -102,7 +112,7 @@ resources:
     interval: 5m
     start: 12:00 AM -0700
     stop: 1:00 AM -0700
-  
+
 jobs:
 - name: something-every-5m-during-midnight-hour
   plan:

--- a/check/main.go
+++ b/check/main.go
@@ -51,6 +51,46 @@ func ParseTime(timeString string) (time.Time, error) {
 	return time.Time{}, errors.New("could not parse time")
 }
 
+func ParseWeekdays(daysList []string) ([]time.Weekday, error) {
+	days := []time.Weekday{}
+
+	for _,d := range daysList {
+			switch d {
+				case "Sunday":
+					days = append(days, time.Sunday)
+				case "Monday":
+					days = append(days, time.Monday)
+				case "Tuesday":
+					days = append(days, time.Tuesday)
+				case "Wednesday":
+					days = append(days, time.Wednesday)
+				case "Thursday":
+					days = append(days, time.Thursday)
+				case "Friday":
+					days = append(days, time.Friday)
+				case "Saturday":
+					days = append(days, time.Saturday)
+				default:
+					return []time.Weekday{}, errors.New("Invalid day " + d)
+			}
+	}
+	return days, nil
+}
+
+func IsInDays(currentTime time.Time, daysList []time.Weekday) bool {
+	if len(daysList) > 0 {
+		currentDay := currentTime.Weekday()
+		for _,d := range daysList {
+			if d == currentDay {
+				return true
+			}
+		}
+		return false
+	}
+
+	return true
+}
+
 func IntervalHasPassed(interval string, versionTime time.Time, currentTime time.Time) (bool, error) {
 	parsedInterval, err := time.ParseDuration(interval)
 
@@ -84,6 +124,12 @@ func main() {
 	lastCheckedAt := request.Version.Time.UTC()
 
 	validateConfig(start, stop, interval)
+
+	days,err := ParseWeekdays(request.Source.Days)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 
 	if start != "" && stop != "" {
 		startTime, err := ParseTime(start)
@@ -137,7 +183,7 @@ func main() {
 		}
 	}
 
-	if incrementVersion {
+	if incrementVersion && IsInDays(currentTime, days){
 		versions = append(versions, models.Version{Time: currentTime})
 	}
 

--- a/in/main.go
+++ b/in/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+	"strings"
 
 	"github.com/concourse/time-resource/models"
 )
@@ -59,6 +60,10 @@ func main() {
 
 	if request.Source.Stop != "" {
 		metadata = append(metadata, models.MetadataField{"stop", request.Source.Stop})
+	}
+
+	if len(request.Source.Days) > 0 {
+		metadata = append(metadata, models.MetadataField{"days", strings.Join(request.Source.Days[:], ", ")})
 	}
 
 	json.NewEncoder(os.Stdout).Encode(models.InResponse{

--- a/models/models.go
+++ b/models/models.go
@@ -36,6 +36,7 @@ type Source struct {
 	Interval string `json:"interval"`
 	Start    string `json:"start"`
 	Stop     string `json:"stop"`
+	Days		 []string `json:"days"`
 }
 
 type Metadata []MetadataField


### PR DESCRIPTION
We like to execute some plans only on workdays (and not on fridays). I added a new attribute "days" to the resource, where you can specify on which days a new version is created. 

If no days are given, the default behaviour is still the same (executed every day). If you set days to monday, interval and start/stop still applies, it is just running on mondays only.

It would be great to see this feature in concourse soon. If you have any questions, feel free to ask. 