### PR TITLE
Add a location parameter in resource source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ level of precision is better left to other tools.
 * `interval`: *Optional.* The interval on which to report new versions. Valid
   values: `60s`, `90m`, `1h`.
 
+* `location`: *Optional.* The location on which time will be calculate. Valid
+  values are a location name corresponding to a file in the IANA Time Zone database,
+  such as "America/New_York". Defaults to `UTC`.
+
 * `start` and `stop`: *Optional.* Only create new time versions between this
   time range. The supported formats for the times are: `3:04 PM -0800`, `3PM
-  -0800`, `3 PM -0800`, `15:04 -0800`, and `1504 -0800`.
+  -0800`, `3 PM -0800`, `15:04 -0800`, `1504 -0800`, `3:04 PM`, `3PM`, `3 PM`
+  , `15:04`, and `1504`.
 
   e.g.
 

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -26,24 +26,46 @@ var _ = Describe("Check", func() {
 	})
 
 	Describe("ParseTime", func() {
-		It("can parse many formats", func() {
-			expectedTime := time.Date(0, 1, 1, 21, 0, 0, 0, time.UTC)
+		Context("with time zone set in formats", func(){
+			It("can parse many formats", func() {
+				expectedTime := time.Date(0, 1, 1, 21, 0, 0, 0, time.UTC)
 
-			formats := []string{
-				"1:00 PM -0800",
-				"1PM -0800",
-				"1 PM -0800",
-				"13:00 -0800",
-				"1300 -0800",
-			}
+				formats := []string{
+					"1:00 PM -0800",
+					"1PM -0800",
+					"1 PM -0800",
+					"13:00 -0800",
+					"1300 -0800",
+				}
+				loc, _ := time.LoadLocation("UTC")
+				for _, format := range formats {
+					By("working with " + format)
+					parsedTime, err := ParseTime(format, loc)
 
-			for _, format := range formats {
-				By("working with " + format)
-				parsedTime, err := ParseTime(format)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(parsedTime.Equal(expectedTime)).To(BeTrue())
+				}
+			})
+		})
+		Context("without time zone set in formats", func(){
+			It("can parse many formats", func() {
+				expectedTime := time.Date(0, 1, 1, 13, 0, 0, 0, time.UTC)
 
-				Expect(err).NotTo(HaveOccurred())
-				Expect(parsedTime.Equal(expectedTime)).To(BeTrue())
-			}
+				formats := []string{
+					"1:00 PM",
+					"1PM",
+					"1 PM",
+					"13:00",
+					"1300",
+				}
+				loc, _ := time.LoadLocation("UTC")
+				for _, format := range formats {
+					By("working with " + format)
+					parsedTime, err := ParseTime(format, loc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(parsedTime.Equal(expectedTime)).To(BeTrue())
+				}
+			})
 		})
 	})
 

--- a/in/main.go
+++ b/in/main.go
@@ -54,6 +54,11 @@ func main() {
 		metadata = append(metadata, models.MetadataField{"interval", request.Source.Interval})
 	}
 
+	if request.Source.Location == "" {
+		request.Source.Location = "UTC"
+	}
+	metadata = append(metadata, models.MetadataField{"location", request.Source.Location})
+
 	if request.Source.Start != "" {
 		metadata = append(metadata, models.MetadataField{"start", request.Source.Start})
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -36,6 +36,7 @@ type Source struct {
 	Interval string   `json:"interval"`
 	Start    string   `json:"start"`
 	Stop     string   `json:"stop"`
+	Location string   `json:"location"`
 	Days     []string `json:"days"`
 }
 

--- a/out/main.go
+++ b/out/main.go
@@ -6,10 +6,26 @@ import (
 	"time"
 
 	"github.com/concourse/time-resource/models"
+	"fmt"
 )
 
 func main() {
-	currentTime := time.Now().UTC()
+	var request models.OutRequest
+
+	err := json.NewDecoder(os.Stdin).Decode(&request)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error decoding payload: "+err.Error())
+		os.Exit(1)
+	}
+	if request.Source.Location == "" {
+		request.Source.Location = "UTC"
+	}
+	loc, err := time.LoadLocation(request.Source.Location)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	currentTime := time.Now().In(loc)
 
 	outVersion := models.Version{
 		Time: currentTime,
@@ -17,6 +33,7 @@ func main() {
 
 	metadata := models.Metadata{
 		{"time", currentTime.String()},
+		{"location", request.Source.Location},
 	}
 
 	json.NewEncoder(os.Stdout).Encode(models.InResponse{


### PR DESCRIPTION
It could be nice to be able to set the location (e.g.: Europe/Paris) for the user like this he could not care about time saving in his country.
For now, we have to set the time zone in start/stop parameter (e.g.: `3 PM +0800`) which are able with this feature just to set the location and omit the time zone, new start and stop values could be simply `3 PM`.

This feature do not change the actual behaviour, the defaults location is set to UTC like it was before.