### PR TITLE
fix start/stop check when in different timezone

### DIFF
--- a/between/between.go
+++ b/between/between.go
@@ -17,6 +17,11 @@ func Between(startBase time.Time, stopBase time.Time, now time.Time) bool {
 	start := now.Truncate(day).Add(startDuration)
 	stop := now.Truncate(day).Add(stopDuration)
 
+	if start.After(now) {
+		start = start.AddDate(0, 0, -1)
+		stop = stop.AddDate(0, 0, -1)
+	}
+
 	if now.Equal(start) {
 		return true
 	}

--- a/between/between_test.go
+++ b/between/between_test.go
@@ -143,9 +143,16 @@ var _ = DescribeTable("Between", (testCase).Run,
 	}),
 
 	Entry("between the start and stop time but the compare time is in a different timezone", testCase{
-		start:         "2:00 AM -0600",
-		stop:          "6:00 AM -0600",
-		timeToCompare: "1:00 AM -0700",
+		start:         "00:01 AM -0700",
+		stop:          "11:59 PM -0700",
+		timeToCompare: "1:10 AM +0000",
 		result:        true,
+	}),
+
+	Entry("not between the start and stop time but the compare time is in a different timezone", testCase{
+		start:         "00:01 AM -0700",
+		stop:          "00:20 AM -0700",
+		timeToCompare: "07:10 AM +0100",
+		result:        false,
 	}),
 )


### PR DESCRIPTION
When we compare the current time against the start and stop time
we used to move start and stop times to the day of current time.
That way we sometimes could loose the begining of the day if it
is in different time zone.