### PR TITLE
Fix checking whether previous time is in range

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -171,29 +171,6 @@ func (tod TimeOfDay) Minute() int {
 	return int(time.Duration(tod) % time.Hour / time.Minute)
 }
 
-func (tod TimeOfDay) In(loc *Location) TimeOfDay {
-	if loc == nil {
-		return tod
-	}
-
-	// without having at least the year, month, and day set, there's no real way
-	// to reason about timezones, as they take effect by laws changing over time
-	referenceTime := time.Now()
-
-	t := time.Date(
-		referenceTime.Year(),
-		referenceTime.Month(),
-		referenceTime.Day(),
-		tod.Hour(),
-		tod.Minute(),
-		0,
-		0,
-		(*time.Location)(loc),
-	)
-
-	return NewTimeOfDay(t.UTC())
-}
-
 func (tod TimeOfDay) String() string {
 	return fmt.Sprintf("%d:%02d", tod.Hour(), tod.Minute())
 }


### PR DESCRIPTION
The existing algorithm checks whether the day of the previous time
is less than the day of the current time, when the two times are
converted to UTC.

This is problematic in two ways:
- It does not ensure that the previous is not in range when the current
time is: the two times could in fact be less than 24 hours apart but in different days.
- It does not allow the resource to trigger after the range has been moved
forward slightly, and Concourse has cached a previous time
less than a day before the current time, even when the previous time
is out of the new range.

This commit fixes the above problems.

This commit also adds new tests which verify that the problems described
above are fixed.

Moreover, the tests are fixed by interpreting test times in the year
2018 instead of the year 0. Without this some tests would fail falsely,
because they expect present time to be in the range when the range is
interpreted at the given location in 2018, but that is not the case when
it is interpreted at the given location in the year 0.