### PR TITLE
Adjust Version.Time for specified location in source configuration.

### DIFF
--- a/check/main.go
+++ b/check/main.go
@@ -28,9 +28,14 @@ func main() {
 	previousTime := request.Version.Time
 	currentTime := time.Now().UTC()
 
+	specifiedLocation := request.Source.Location
+	if specifiedLocation != nil {
+		currentTime = currentTime.In((*time.Location)(specifiedLocation))
+	}
+
 	tl := lord.TimeLord{
 		PreviousTime: previousTime,
-		Location:     request.Source.Location,
+		Location:     specifiedLocation,
 		Start:        request.Source.Start,
 		Stop:         request.Source.Stop,
 		Interval:     request.Source.Interval,

--- a/out/main.go
+++ b/out/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
@@ -9,8 +10,19 @@ import (
 )
 
 func main() {
-	currentTime := time.Now().UTC()
+	var request models.OutRequest
 
+	err := json.NewDecoder(os.Stdin).Decode(&request)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parse error:", err.Error())
+		os.Exit(1)
+	}
+
+	currentTime := time.Now().UTC()
+	specifiedLocation := request.Source.Location
+	if specifiedLocation != nil {
+		currentTime = currentTime.In((*time.Location)(specifiedLocation))
+	}
 
 	outVersion := models.Version{
 		Time: currentTime,

--- a/out/main.go
+++ b/out/main.go
@@ -11,6 +11,7 @@ import (
 func main() {
 	currentTime := time.Now().UTC()
 
+
 	outVersion := models.Version{
 		Time: currentTime,
 	}

--- a/out/out_test.go
+++ b/out/out_test.go
@@ -1,12 +1,12 @@
 package main_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/concourse/time-resource/models"
@@ -20,6 +20,7 @@ var _ = Describe("Out", func() {
 	var source string
 
 	var outCmd *exec.Cmd
+	var now time.Time
 
 	BeforeEach(func() {
 		var err error
@@ -30,6 +31,7 @@ var _ = Describe("Out", func() {
 		source = path.Join(tmpdir, "out-dir")
 
 		outCmd = exec.Command(outPath, source)
+		now = time.Now().UTC()
 	})
 
 	AfterEach(func() {
@@ -37,28 +39,24 @@ var _ = Describe("Out", func() {
 	})
 
 	Context("when executed", func() {
-		var request models.OutRequest
+		var source map[string]interface{}
 		var response models.OutResponse
 
 		BeforeEach(func() {
-			interval := models.Interval(time.Second)
-
-			request = models.OutRequest{
-				Source: models.Source{Interval: &interval},
-			}
-
+			source = map[string]interface{}{}
 			response = models.OutResponse{}
 		})
 
 		JustBeforeEach(func() {
-			stdin := new(bytes.Buffer)
-
-			err := json.NewEncoder(stdin).Encode(request)
+			stdin, err := outCmd.StdinPipe()
 			Expect(err).NotTo(HaveOccurred())
 
-			outCmd.Stdin = stdin
-
 			session, err := gexec.Start(outCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = json.NewEncoder(stdin).Encode(map[string]interface{}{
+				"source": source,
+			})
 			Expect(err).NotTo(HaveOccurred())
 
 			<-session.Exited
@@ -68,8 +66,29 @@ var _ = Describe("Out", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("reports the current time as the version", func() {
-			Expect(response.Version.Time).To(BeTemporally("~", time.Now(), time.Second))
+		Context("when a location is specified", func() {
+			var loc *time.Location
+
+			BeforeEach(func() {
+				var err error
+				loc, err = time.LoadLocation("America/Indiana/Indianapolis")
+				Expect(err).ToNot(HaveOccurred())
+
+				source["location"] = loc.String()
+
+				now = now.In(loc)
+			})
+
+			It("reports specified location's current time(offset: -0500) as the version", func() {
+				contained := strings.Contains(response.Version.Time.String(), "-0500")
+				Expect(contained).To(BeTrue())
+			})
+		})
+		Context("when a location is not specified", func() {
+			It("reports the current time(offset: 0000) as the version", func() {
+				contained := strings.Contains(response.Version.Time.String(), "0000")
+				Expect(contained).To(BeTrue())
+			})
 		})
 	})
 })

--- a/out/out_test.go
+++ b/out/out_test.go
@@ -79,8 +79,8 @@ var _ = Describe("Out", func() {
 				now = now.In(loc)
 			})
 
-			It("reports specified location's current time(offset: -0500) as the version", func() {
-				contained := strings.Contains(response.Version.Time.String(), "-0500")
+			It("reports specified location's current time(offset: -0400) as the version", func() {
+				contained := strings.Contains(response.Version.Time.String(), "-0400")
 				Expect(contained).To(BeTrue())
 			})
 		})

--- a/out/out_test.go
+++ b/out/out_test.go
@@ -80,12 +80,16 @@ var _ = Describe("Out", func() {
 			})
 
 			It("reports specified location's current time(offset: -0400) as the version", func() {
+				// An example of response.Version.Time.String() is
+				// 2019-04-03 14:53:10.951241 -0400 EDT
 				contained := strings.Contains(response.Version.Time.String(), "-0400")
 				Expect(contained).To(BeTrue())
 			})
 		})
 		Context("when a location is not specified", func() {
 			It("reports the current time(offset: 0000) as the version", func() {
+				// An example of response.Version.Time.String() is
+				// 2019-04-03 18:53:10.964705 +0000 UTC
 				contained := strings.Contains(response.Version.Time.String(), "0000")
 				Expect(contained).To(BeTrue())
 			})


### PR DESCRIPTION
* Before
  * We set `location` in source configuration, but versioned time is utc...
* After
  * We set `location` in source configuration, so versioned time is specified location's time.