### PR TITLE
out uses `models.OutResponse`

### DIFF
--- a/out/main.go
+++ b/out/main.go
@@ -15,7 +15,7 @@ func main() {
 		Time: currentTime,
 	}
 
-	json.NewEncoder(os.Stdout).Encode(models.InResponse{
+	json.NewEncoder(os.Stdout).Encode(models.OutResponse{
 		Version: outVersion,
 	})
 }


### PR DESCRIPTION
Presumably, the use of `models.InResponse` in `out/main.go`
was a typo. This corrects the typo to use a `models.OutResponse`.

fixes issue #37