### PR TITLE
Added ability to inject delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,19 @@ destination.
 
 #### Parameters
 
-*None.*
+* `wait`: *Optional.* If `true`, pauses execution until the given timestamp.
 
 
 ### `out`: Produce the current time.
 
-Returns a version for the current timestamp. This can be used to record the
-time within a build plan, e.g. after running some long-running task.
+Returns a version for the specified timestamp. This can be used to record the
+current time within a build plan, e.g. after running some long-running task,
+or to calculate a future timestamp.
 
 #### Parameters
 
-*None.*
+* `after`: *Optional.* The interval to add to the current time when creating a
+new version. Valid values: `60s`, `90m`, `1h`.
 
 
 ## Examples

--- a/in/in_test.go
+++ b/in/in_test.go
@@ -93,5 +93,26 @@ var _ = Describe("In", func() {
 				Expect(response.Version.Time.Unix()).To(BeNumerically("~", time.Now().Unix(), 1))
 			})
 		})
+		Context("when the request has a future time in its version", func() {
+			duration := time.Second * 10
+
+			BeforeEach(func() {
+				request.Version.Time = time.Now().Add(duration)
+			})
+
+			It("reports the future time as the version", func() {
+				Expect(response.Version.Time.Unix()).To(BeNumerically(">", time.Now().Unix(), duration))
+			})
+
+			Context("waits for the future time", func() {
+				BeforeEach(func() {
+					request.Params.Wait = true
+				})
+
+				It("waits until the future time has been reached", func() {
+					Expect(response.Version.Time.Unix()).To(BeNumerically("~", time.Now().Unix(), 1))
+				})
+			})
+		})
 	})
 })

--- a/in/main.go
+++ b/in/main.go
@@ -42,6 +42,10 @@ func main() {
 		versionTime = time.Now()
 	}
 
+	if request.Params.Wait {
+		time.Sleep(time.Until(versionTime))
+	}
+
 	inVersion := request.Version
 	inVersion.Time = versionTime
 

--- a/models/models.go
+++ b/models/models.go
@@ -13,8 +13,9 @@ type Version struct {
 }
 
 type InRequest struct {
-	Source  Source  `json:"source"`
-	Version Version `json:"version"`
+	Source  Source   `json:"source"`
+	Version Version  `json:"version"`
+	Params  InParams `json:"params"`
 }
 
 type InResponse struct {
@@ -22,13 +23,22 @@ type InResponse struct {
 	Metadata Metadata `json:"metadata"`
 }
 
+type InParams struct {
+	Wait bool `json:"wait"`
+}
+
 type OutRequest struct {
-	Source Source `json:"source"`
+	Source Source    `json:"source"`
+	Params OutParams `json:"params"`
 }
 
 type OutResponse struct {
 	Version  Version  `json:"version"`
 	Metadata Metadata `json:"metadata"`
+}
+
+type OutParams struct {
+	After *Interval `json:"after"`
 }
 
 type CheckRequest struct {

--- a/out/main.go
+++ b/out/main.go
@@ -18,14 +18,20 @@ func main() {
 		os.Exit(1)
 	}
 
-	currentTime := time.Now().UTC()
+	versionTime := time.Now().UTC()
+
+	specifiedDelay := request.Params.After
+	if specifiedDelay != nil {
+		versionTime = versionTime.Add((time.Duration)(*specifiedDelay))
+	}
+
 	specifiedLocation := request.Source.Location
 	if specifiedLocation != nil {
-		currentTime = currentTime.In((*time.Location)(specifiedLocation))
+		versionTime = versionTime.In((*time.Location)(specifiedLocation))
 	}
 
 	outVersion := models.Version{
-		Time: currentTime,
+		Time: versionTime,
 	}
 
 	json.NewEncoder(os.Stdout).Encode(models.OutResponse{


### PR DESCRIPTION
As a developer, I want the ability to inject a fixed delay in to my build plan so that I can account for long-running operations that cannot easily be accessed via Concourse (e.g. replication, provisioning).