### PR TITLE
Added LaxCheck flag to Source model

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ level of precision is better left to other tools.
 
 ## Source Configuration
 
-* `interval`: *Optional.* The interval on which to report new versions. Valid
-  values: `60s`, `90m`, `1h`.
+* `skip_check`: *Optional. Default `false`.* If `true`, disables the reporting
+  of new versions based on system time and restricts the reporting of new
+  versions to `put` steps in a pipeline.
+
+* `interval`: *Optional. Required unless `start` and `stop` are defined.* The
+  interval on which to report new versions. Valid examples: `60s`, `90m`, `1h`.
 
 * `location`: *Optional. Default `UTC`.* The
   [location](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) in
@@ -24,7 +28,8 @@ level of precision is better left to other tools.
 
 * `start` and `stop`: *Optional.* Only create new time versions between this
   time range. The supported formats for the times are: `3:04 PM`, `3PM`, `3
-  PM`, `15:04`, and `1504`.
+  PM`, `15:04`, and `1504`. If a `start` is specified, a `stop` must also be
+  specified, and vice versa.
 
   e.g.
 

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -507,6 +507,32 @@ var _ = Describe("Check", func() {
 				})
 			})
 		})
+
+		Context("with checking skipped", func() {
+			BeforeEach(func() {
+				source["skip_check"] = true
+			})
+
+			Context("when no version is given", func() {
+				It("does not output any versions", func() {
+					Expect(response).To(BeEmpty())
+				})
+			})
+
+			Context("when a version is given", func() {
+				var prev time.Time
+
+				BeforeEach(func() {
+					prev = now.Add(-30 * time.Minute)
+					version = &models.Version{Time: prev}
+				})
+
+				It("outputs the supplied version", func() {
+					Expect(response).To(HaveLen(1))
+					Expect(response[0].Time.Unix()).To(Equal(prev.Unix()))
+				})
+			})
+		})
 	})
 
 	Context("with invalid inputs", func() {

--- a/check/main.go
+++ b/check/main.go
@@ -48,7 +48,7 @@ func main() {
 		versions = append(versions, models.Version{Time: previousTime})
 	}
 
-	if tl.Check(currentTime) {
+	if request.Source.SkipCheck == false && tl.Check(currentTime) {
 		versions = append(versions, models.Version{Time: currentTime})
 	}
 

--- a/models/models.go
+++ b/models/models.go
@@ -39,15 +39,16 @@ type CheckRequest struct {
 type CheckResponse []Version
 
 type Source struct {
-	Interval *Interval  `json:"interval"`
-	Start    *TimeOfDay `json:"start"`
-	Stop     *TimeOfDay `json:"stop"`
-	Days     []Weekday  `json:"days"`
-	Location *Location  `json:"location"`
+	SkipCheck bool       `json:"skip_check"`
+	Interval  *Interval  `json:"interval"`
+	Start     *TimeOfDay `json:"start"`
+	Stop      *TimeOfDay `json:"stop"`
+	Days      []Weekday  `json:"days"`
+	Location  *Location  `json:"location"`
 }
 
 func (source Source) Validate() error {
-	if source.Interval == nil && source.Start == nil && source.Stop == nil {
+	if source.Interval == nil && source.Start == nil && source.Stop == nil && source.SkipCheck == false {
 		return errors.New("must configure either 'interval' or 'start' and 'stop'")
 	}
 


### PR DESCRIPTION
This change adds a boolean flag to the `Source` model that disables the creation of new versions via the `check` function.

One consideration I had was making the new attribute a `*bool`. Adding a new attribute to the Source configuration will purge the history for any instances of the time resource (due to https://github.com/concourse/concourse/issues/3910). But making it a pointer makes the changes a bit... messier.

Fixes #23, #44 