### PR TITLE
Use instance vars to compute hash for unique intervals

### DIFF
--- a/offset.go
+++ b/offset.go
@@ -12,14 +12,19 @@ import (
 
 const BUILD_TEAM_NAME = "BUILD_TEAM_NAME"
 const BUILD_PIPELINE_NAME = "BUILD_PIPELINE_NAME"
-const offsetHashFormat = "%s/%s"
+const BUILD_PIPELINE_INSTANCE_VARS = "BUILD_PIPELINE_INSTANCE_VARS"
 
 const maxHashValue = int64(math.MaxUint32)
 
 var msPerMinute = time.Minute.Milliseconds()
 
 func Offset(tl lord.TimeLord, reference time.Time) time.Time {
-	str := fmt.Sprintf(offsetHashFormat, os.Getenv(BUILD_TEAM_NAME), os.Getenv(BUILD_PIPELINE_NAME))
+	str := fmt.Sprintf(
+		"%s/%s/%s",
+		os.Getenv(BUILD_TEAM_NAME),
+		os.Getenv(BUILD_PIPELINE_NAME),
+		os.Getenv(BUILD_PIPELINE_INSTANCE_VARS),
+	)
 	hasher := fnv.New32a()
 	if _, err := hasher.Write([]byte(str)); err != nil {
 		fmt.Fprintln(os.Stderr, "hash error:", err.Error())

--- a/offset_test.go
+++ b/offset_test.go
@@ -12,38 +12,44 @@ import (
 )
 
 type testEnvironment struct {
-	teamName       string
-	pipelineName   string
-	hashPercentile float64
+	teamName             string
+	pipelineName         string
+	pipelineInstanceVars string
+	hashPercentile       float64
 }
 
 var xsmallOffset = testEnvironment{
-	teamName:       "",
-	pipelineName:   "",
-	hashPercentile: 0.16425462769,
+	teamName:             "a",
+	pipelineName:         "b",
+	pipelineInstanceVars: "",
+	hashPercentile:       0.11040721324049105,
 }
 
 var smallOffset = testEnvironment{
-	teamName:       "concourse",
-	pipelineName:   "time-resource",
-	hashPercentile: 0.49905898922,
+	teamName:             "concourse",
+	pipelineName:         "time-resource",
+	pipelineInstanceVars: "",
+	hashPercentile:       0.4723325777967303,
 }
 
 var largeOffset = testEnvironment{
-	teamName:       "concourse",
-	pipelineName:   "concourse",
-	hashPercentile: 0.6995269071,
+	teamName:             "concourse",
+	pipelineName:         "concourse",
+	pipelineInstanceVars: "large",
+	hashPercentile:       0.8069350870342309,
 }
 
 var xlargeOffset = testEnvironment{
-	teamName:       "foo",
-	pipelineName:   "bar",
-	hashPercentile: 0.77989363246,
+	teamName:             "foo",
+	pipelineName:         "bar",
+	pipelineInstanceVars: "baz",
+	hashPercentile:       0.9322489704778998,
 }
 
 var _ = Describe("Offset", func() {
 	originalTeam := os.Getenv(resource.BUILD_TEAM_NAME)
 	originalPipeline := os.Getenv(resource.BUILD_PIPELINE_NAME)
+	originalPipelineInstanceVars := os.Getenv(resource.BUILD_PIPELINE_INSTANCE_VARS)
 
 	var (
 		env testEnvironment
@@ -68,12 +74,14 @@ var _ = Describe("Offset", func() {
 	JustBeforeEach(func() {
 		os.Setenv(resource.BUILD_TEAM_NAME, env.teamName)
 		os.Setenv(resource.BUILD_PIPELINE_NAME, env.pipelineName)
+		os.Setenv(resource.BUILD_PIPELINE_INSTANCE_VARS, env.pipelineInstanceVars)
 		actualOffsetTime = resource.Offset(tl, reference)
 	})
 
 	AfterEach(func() {
 		os.Setenv(resource.BUILD_TEAM_NAME, originalTeam)
 		os.Setenv(resource.BUILD_PIPELINE_NAME, originalPipeline)
+		os.Setenv(resource.BUILD_PIPELINE_INSTANCE_VARS, originalPipelineInstanceVars)
 	})
 
 	validateExpectedTime := func() {
@@ -135,7 +143,7 @@ var _ = Describe("Offset", func() {
 					})
 
 					for _, testEnv := range []testEnvironment{xsmallOffset, smallOffset, largeOffset, xlargeOffset} {
-						Context("for the "+env.teamName+"/"+env.pipelineName+" pipeline", func() {
+						Context("for the "+env.teamName+"/"+env.pipelineName+"/"+env.pipelineInstanceVars+" pipeline", func() {
 							BeforeEach(func() {
 								env = testEnv
 								expectedOffsetTime = reference.Truncate(time.Minute)
@@ -266,7 +274,7 @@ var _ = Describe("Offset", func() {
 					})
 
 					for _, testEnv := range []testEnvironment{xsmallOffset, smallOffset, largeOffset, xlargeOffset} {
-						Context("for the "+env.teamName+"/"+env.pipelineName+" pipeline", func() {
+						Context("for the "+env.teamName+"/"+env.pipelineName+"/"+env.pipelineInstanceVars+" pipeline", func() {
 							BeforeEach(func() {
 								env = testEnv
 								expectedOffsetTime = reference.Truncate(time.Minute)


### PR DESCRIPTION
#54 ensured even distribution for a given interval per pipeline based on team name + pipeline name, but this doesn't work for pipeline instances since they have the same team + pipeline name