### PR TITLE
Add note to start/stop documentation to quote timestamp values if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ level of precision is better left to other tools.
   stop: 6:00 AM
   ```
 
+  **Note: YAML parsers like PyYAML may parse time values in the 24h format as integers, not strings (e.g. `19:00` is parsed as `1140`). If you pre-process your pipeline configuration with such a parser this might trigger a marshaling error. In that case you can quote your `start` and `stop` values, so they will be correctly treated as string.**
+
 * `days`: *Optional.* Limit the creation of new time versions to the specified
   day(s). Supported days are: `Sunday`, `Monday`, `Tuesday`, `Wednesday`,
   `Thursday`, `Friday` and `Saturday`.


### PR DESCRIPTION
Using PyYaml as pre-processor for pipeline YAML will trigger a marshaling error when using `start`/`stop` values in the 24h format (e.g. `19:00`). [Apparently this is a known issue](https://stackoverflow.com/questions/23812676/pyyaml-parses-900-as-int).

For example a `'source:\n  start: 19:00\n'` is parsed into `{'source': {'start': 1140}}` instead of the expected `{'source': {'start': '19:00'}}` ([see this Online YAML Parser](https://yaml-online-parser.appspot.com/?yaml=resources%3A%0A-%20name%3A%20daily%0A%20%20type%3A%20time%0A%20%20source%3A%0A%20%20%20%20start%3A%2019%3A00%0A%20%20%20%20stop%3A%2020%3A00%0A%20%20%20%20location%3A%20Europe/Berlin&type=json)).

Since this is only an issue if you pre-process or transform your YAML, there is no need to change the whole documentation (in the end this is no issue with this resource). But a note in the `start`/`stop` section will probably be helpful for other users.