### PR TITLE
Add support for "initial_version" to allow auto-populating the first version

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,38 @@ level of precision is better left to other tools.
 These can be combined to emit a new version on an interval during a particular
 time period.
 
+* `initial_version`: *Optional.* When using `start` and `stop` as a trigger for
+  a job, you will be unable to run the job manually until it goes into the
+  configured time range for the first time (manual runs will work once the `time`
+  resource has produced it's first version).
+
+  To get around this issue, there are two approaches.
+     * Use `initial_version: true`, which will produce a new version that is
+       set to the current time, if `check` runs and there isn't already a version
+       specified. This has a downside that if used with `trigger: true`, it will
+       kick off the correlating job when the pipeline is first created, even
+       outside of the specified window.
+     * Once you push a pipeline that utilizes `start` and `stop`, run the
+       following fly command to run the resource check from a previous point
+       in time (see [this issue](https://github.com/concourse/time-resource/issues/24#issuecomment-689422764)
+       for 6.x.x+ or [this issue](https://github.com/concourse/time-resource/issues/11#issuecomment-562385742)
+       for older Concourse versions).
+
+       ```
+       fly -t <your target> \
+         check-resource <your resource>
+         --from "time:2000-01-01T00:00:00Z" # the important part
+       ```
+
+       This has the benefit that it shouldn't trigger that initial job run, but
+       will still allow you to manually run the job if needed.
+
+  e.g.
+
+  ```
+  initial_version: true
+  ```
+
 ## Behavior
 
 ### `check`: Produce timestamps satisfying the interval.

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ level of precision is better left to other tools.
   configured time range for the first time (manual runs will work once the `time`
   resource has produced it's first version).
 
-  To get around this issue, there are two approaches.
+  To get around this issue, there are two approaches:
      * Use `initial_version: true`, which will produce a new version that is
        set to the current time, if `check` runs and there isn't already a version
-       specified. This has a downside that if used with `trigger: true`, it will
+       specified. **NOTE: This has a downside that if used with `trigger: true`, it will
        kick off the correlating job when the pipeline is first created, even
-       outside of the specified window.
-     * Once you push a pipeline that utilizes `start` and `stop`, run the
+       outside of the specified window**.
+     * Alternatively, once you push a pipeline that utilizes `start` and `stop`, run the
        following fly command to run the resource check from a previous point
        in time (see [this issue](https://github.com/concourse/time-resource/issues/24#issuecomment-689422764)
        for 6.x.x+ or [this issue](https://github.com/concourse/time-resource/issues/11#issuecomment-562385742)

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ level of precision is better left to other tools.
   days: [Monday, Wednesday]
   ```
 
-These can be combined to emit a new version on an interval during a particular
-time period.
+  These can be combined to emit a new version on an interval during a particular
+  time period.
 
 * `initial_version`: *Optional.* When using `start` and `stop` as a trigger for
   a job, you will be unable to run the job manually until it goes into the

--- a/check_command.go
+++ b/check_command.go
@@ -37,6 +37,9 @@ func (*CheckCommand) Run(request models.CheckRequest) ([]models.Version, error) 
 
 	if !previousTime.IsZero() {
 		versions = append(versions, models.Version{Time: previousTime})
+	} else if request.Source.InitialVersion {
+		versions = append(versions, models.Version{Time: currentTime})
+		return versions, nil
 	}
 
 	if tl.Check(currentTime) {

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_image
+ARG base_image=ubuntu:latest
 ARG builder_image=concourse/golang-builder
 
 FROM ${builder_image} AS builder
@@ -12,19 +12,19 @@ RUN go build -o /assets/out github.com/concourse/time-resource/out
 RUN go build -o /assets/in github.com/concourse/time-resource/in
 RUN go build -o /assets/check github.com/concourse/time-resource/check
 RUN set -e; for pkg in $(go list ./...); do \
-		go test -o "/tests/$(basename $pkg).test" -c $pkg; \
+	go test -o "/tests/$(basename $pkg).test" -c $pkg; \
 	done
 
 FROM ${base_image} AS resource
 RUN apt update && apt upgrade -y -o Dpkg::Options::="--force-confdef"
 RUN apt update && apt install -y --no-install-recommends tzdata \
-    && rm -rf /var/lib/apt/lists/*
+	&& rm -rf /var/lib/apt/lists/*
 COPY --from=builder /assets /opt/resource
 
 FROM resource AS tests
 COPY --from=builder /tests /tests
 RUN set -e; for test in /tests/*.test; do \
-		$test; \
+	$test; \
 	done
 
 FROM resource

--- a/models/models.go
+++ b/models/models.go
@@ -39,11 +39,12 @@ type CheckRequest struct {
 type CheckResponse []Version
 
 type Source struct {
-	Interval *Interval  `json:"interval"`
-	Start    *TimeOfDay `json:"start"`
-	Stop     *TimeOfDay `json:"stop"`
-	Days     []Weekday  `json:"days"`
-	Location *Location  `json:"location"`
+	InitialVersion bool       `json:"initial_version"`
+	Interval       *Interval  `json:"interval"`
+	Start          *TimeOfDay `json:"start"`
+	Stop           *TimeOfDay `json:"stop"`
+	Days           []Weekday  `json:"days"`
+	Location       *Location  `json:"location"`
 }
 
 func (source Source) Validate() error {


### PR DESCRIPTION
This PR adds support for optionally generating the first version initially (when using `start` and `stop`), even if it hasn't gone into the first time window yet. This is very helpful for adding the ability to manually run the job, as Concourse does not let you run a job when it has an input that's set to `trigger: true` and an input with no versions yet.

Does it make more sense to output something like `time.Time{}`, as that obviously is more obvious that it's some kind of default timestamp -- or, output the current time like I'm doing now? I.e. if the user did set `initial_version`, it's not inherently obvious if other people look at the pipeline and the `time` resource versions, that it was due to this new field.

* Closes: https://github.com/concourse/time-resource/issues/24
* Closes: https://github.com/concourse/time-resource/issues/11#issuecomment-562385742

I'm not 100% sure this is the overall best solution, but to me it seems like the most straightforward way until there are enhancements to Concourse itself.