### PR TITLE
add epoch file to time resource output

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ given version, or if there is no version given.
 
 ### `in`: Report the given time.
 
-Fetches the given timestamp. Creates two files:
+Fetches the given timestamp. Creates three files:
 1. `input` which contains the request provided by Concourse
 1. `timestamp` which contains the fetched version in the following format: `2006-01-02 15:04:05.999999999 -0700 MST`
 1. `epoch` which contains the fetched version as a Unix epoch Timestamp (integer only)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ given version, or if there is no version given.
 Fetches the given timestamp. Creates two files:
 1. `input` which contains the request provided by Concourse
 1. `timestamp` which contains the fetched version in the following format: `2006-01-02 15:04:05.999999999 -0700 MST`
+1. `epoch` which contains the fetched version as a Unix epoch Timestamp (integer only)
 
 #### Parameters
 

--- a/in_command.go
+++ b/in_command.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/concourse/time-resource/models"
@@ -45,6 +46,12 @@ func (*InCommand) Run(destination string, request models.InRequest) (models.InRe
 	if err != nil {
 		return models.InResponse{}, fmt.Errorf("writing timestamp file: %w", err)
 	}
+
+	epochFile, err := os.Create(filepath.Join(destination, "epoch"))
+	if err != nil {
+		return models.InResponse{}, fmt.Errorf("creating epoch file: %w", err)
+	}
+	epochFile.WriteString(strconv.FormatInt(versionTime.Unix(), 10))
 
 	inVersion := models.Version{Time: versionTime}
 	response := models.InResponse{Version: inVersion}

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	resource "github.com/concourse/time-resource"
@@ -77,9 +78,15 @@ var _ = Describe("In", func() {
 			input, err := os.ReadFile(filepath.Join(destination, "timestamp"))
 			Expect(err).NotTo(HaveOccurred())
 
+			epoch, err := os.ReadFile(filepath.Join(destination, "epoch"))
+			Expect(err).NotTo(HaveOccurred())
+			epochi, err := strconv.Atoi(string(epoch))
+			Expect(err).NotTo(HaveOccurred())
+
 			givenTime, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", string(input))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(givenTime.Unix()).To(Equal(version.Time.Unix()))
+			Expect(givenTime.Unix()).To(Equal(int64(epochi)))
 		})
 
 		Context("when the request has no time in its version", func() {


### PR DESCRIPTION
In my case it is desirable to have the time as a timestamp, instead of the current format.

This is also (in my opinion) easier for other tools downstream to consume than the current format is.