### PR TITLE
Add support for `start_after` to restrict resource version generation to on/after a specified date/time

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,21 @@ level of precision is better left to other tools.
   ```
   initial_version: true
   ```
+* `start_after`: *Optional.* Specifies the earliest datetime from which new time-based versions can be created.  
 
+  Supported formats are `2006-01-02 15:04:05`, `2006-01-02T15:04:05`, `2006-01-02T15:04`, `2006-01-02T15`, `2006-01-02`.
+
+  Behavior:
+  - If the `start_after` datetime is specified and is in the future, it will determine when the first version is created.
+  - If the `start_after` datetime is in the past, the resource will continue to generate versions based on the other configuration parameters.
+  - When `initial_version` is set to true, the first version will be created based on the current time. Subsequent versions will only be generated if they fall after the `start_after` datetime.
+  - If a `location` is provided, the `start_after` datetime will be interpreted in the context of the specified timezone, rather than in UTC.
+
+  e.g.
+
+  ```
+  start_after: 2023-10-01T00:00:00
+  ```
 ## Behavior
 
 ### `check`: Produce timestamps satisfying the interval.
@@ -185,6 +199,25 @@ jobs:
   - get: 5m-during-midnight-hour
     trigger: true
   - task: something
+    config: # ...
+```
+
+### Trigger on/after specific datetime set
+
+```yaml
+resources:
+- name: time-based-resource
+  type: time
+  source:
+    start_after: 2023-12-01T09:00:00
+    location: America/New_York
+
+jobs:
+- name: process-time-based-resource
+  plan:
+  - get: time-based-resource
+    trigger: true
+  - task: process-data
     config: # ...
 ```
 

--- a/check_command.go
+++ b/check_command.go
@@ -31,6 +31,7 @@ func (*CheckCommand) Run(request models.CheckRequest) ([]models.Version, error) 
 		Stop:         request.Source.Stop,
 		Interval:     request.Source.Interval,
 		Days:         request.Source.Days,
+		StartAfter:   request.Source.StartAfter,
 	}
 
 	var versions []models.Version

--- a/check_command_test.go
+++ b/check_command_test.go
@@ -558,8 +558,10 @@ var _ = Describe("Check", func() {
 						Expect(response[1].Time.Unix()).To(BeNumerically("~", time.Now().Unix(), 1))
 					})
 				})
+			})
 
-				Context("when the current time is before start_after and InitialVersion is true", func() {
+			Context("when initial_version is specified", func() {
+				Context("when the current time is before start_after and initial_version is true", func() {
 					BeforeEach(func() {
 						startAfter := now.Add(1 * time.Hour)
 						source.StartAfter = (*models.StartAfter)(&startAfter)
@@ -572,7 +574,7 @@ var _ = Describe("Check", func() {
 					})
 				})
 
-				Context("when the current time is after start_after and InitialVersion is true", func() {
+				Context("when the current time is after start_after and initial_version is true", func() {
 					BeforeEach(func() {
 						startAfter := now.Add(-1 * time.Hour)
 						source.StartAfter = (*models.StartAfter)(&startAfter)
@@ -585,7 +587,7 @@ var _ = Describe("Check", func() {
 					})
 				})
 
-				Context("when the current time is before start_after and InitialVersion is false", func() {
+				Context("when the current time is before start_after and initial_version is false", func() {
 					BeforeEach(func() {
 						startAfter := now.Add(1 * time.Hour)
 						source.StartAfter = (*models.StartAfter)(&startAfter)
@@ -597,7 +599,7 @@ var _ = Describe("Check", func() {
 					})
 				})
 
-				Context("when the current time is after start_after and InitialVersion is false", func() {
+				Context("when the current time is after start_after and initial_version is false", func() {
 					BeforeEach(func() {
 						startAfter := now.Add(-1 * time.Hour)
 						source.StartAfter = (*models.StartAfter)(&startAfter)

--- a/lord/time_lord.go
+++ b/lord/time_lord.go
@@ -15,6 +15,7 @@ type TimeLord struct {
 	Stop         *models.TimeOfDay
 	Interval     *models.Interval
 	Days         []models.Weekday
+	StartAfter   *models.StartAfter
 }
 
 func (tl TimeLord) Check(now time.Time) bool {
@@ -23,6 +24,16 @@ func (tl TimeLord) Check(now time.Time) bool {
 
 	if !tl.daysMatch(now) {
 		return false
+	}
+
+	if tl.StartAfter != nil {
+		startAfter := time.Time(*tl.StartAfter)
+		startInLoc := time.Date(startAfter.Year(), startAfter.Month(), startAfter.Day(),
+			startAfter.Hour(), startAfter.Minute(), startAfter.Second(), 0, tl.loc())
+
+		if !startInLoc.Before(now) {
+			return false
+		}
 	}
 
 	if !start.IsZero() && (now.Before(start) || !now.Before(stop)) {

--- a/lord/time_lord_test.go
+++ b/lord/time_lord_test.go
@@ -27,8 +27,9 @@ type testCase struct {
 
 	days []time.Weekday
 
-	prev    string
-	prevDay time.Weekday
+	start_after string
+	prev        string
+	prevDay     time.Weekday
 
 	now       string
 	extraTime time.Duration
@@ -41,6 +42,7 @@ type testCase struct {
 
 const exampleFormatWithTZ = "3:04 PM -0700 2006"
 const exampleFormatWithoutTZ = "3:04 PM 2006"
+const iso8601Format = "2006-01-02T15:04:05"
 
 func (tc testCase) Run() {
 	var tl lord.TimeLord
@@ -57,6 +59,13 @@ func (tc testCase) Run() {
 		format = exampleFormatWithoutTZ
 	} else {
 		format = exampleFormatWithTZ
+	}
+
+	if tc.start_after != "" {
+		startTime, err := time.Parse(iso8601Format, tc.start_after)
+		Expect(err).NotTo(HaveOccurred())
+		startTimeModel := models.StartAfter(startTime.UTC())
+		tl.StartAfter = &startTimeModel
 	}
 
 	if tc.start != "" {
@@ -454,5 +463,98 @@ var _ = DescribeTable("A range with an interval and a previous time", (testCase)
 
 		result: false,
 		latest: expectedTime{hour: 14, minute: 58},
+	}),
+)
+
+var _ = DescribeTable("Start time with a range and interval", (testCase).Run,
+	Entry("start_after is in the future, now is before start_after", testCase{
+		interval:    "2m",
+		start:       "1:00 PM +0000",
+		stop:        "3:00 PM +0000",
+		start_after: "2025-01-01T00:00:00",
+		now:         "3:06 AM +0000",
+		result:      false,
+		latest:      expectedTime{isZero: true},
+	}),
+	Entry("start_after is in the future, now is after start_after but before range", testCase{
+		interval:    "2m",
+		start:       "1:00 PM +0000",
+		stop:        "3:00 PM +0000",
+		start_after: "2025-01-01T00:00:00",
+		now:         "12:00 PM +0000",
+		result:      false,
+		latest:      expectedTime{isZero: true},
+	}),
+	Entry("start_after is in the past, now is within the range", testCase{
+		interval:    "2m",
+		start:       "1:00 PM +0000",
+		stop:        "3:00 PM +0000",
+		start_after: "2017-12-31T00:00:00",
+		now:         "1:30 PM +0000",
+		result:      true,
+		latest:      expectedTime{hour: 13, minute: 30},
+	}),
+	Entry("start_after is in the past, now is outside the range", testCase{
+		interval:    "2m",
+		start:       "1:00 PM +0000",
+		stop:        "3:00 PM +0000",
+		start_after: "2017-12-31T00:00:00",
+		now:         "4:00 PM +0000",
+		result:      false,
+		latest:      expectedTime{isZero: true},
+	}),
+	Entry("start_after is in the past, now is before the range", testCase{
+		interval:    "2m",
+		start:       "1:00 PM +0000",
+		stop:        "3:00 PM +0000",
+		start_after: "2017-12-31T00:00:00",
+		now:         "12:00 PM +0000",
+		result:      false,
+		latest:      expectedTime{isZero: true},
+	}),
+	Entry("start_after is in the past, now is exactly at the start of the range", testCase{
+		interval:    "2m",
+		start:       "1:00 PM +0000",
+		stop:        "3:00 PM +0000",
+		start_after: "2017-12-31T00:00:00",
+		now:         "1:00 PM +0000",
+		result:      true,
+		latest:      expectedTime{hour: 13, minute: 0},
+	}),
+	Entry("start_after is in the past, now is exactly at the stop of the range", testCase{
+		interval:    "2m",
+		start:       "1:00 PM +0000",
+		stop:        "3:00 PM +0000",
+		start_after: "2017-12-31T00:00:00",
+		now:         "3:00 PM +0000",
+		result:      false,
+		latest:      expectedTime{isZero: true},
+	}),
+	Entry("start_after is in the past, now is in the range with location", testCase{
+		location:    "America/Indiana/Indianapolis",
+		start:       "1:00 PM",
+		stop:        "3:00 PM",
+		now:         "6:05 PM +0000",
+		start_after: "2017-12-31T00:00:00",
+		result:      true,
+		latest:      expectedTime{hour: 13, minute: 0},
+	}),
+	Entry("start_after is in the past, now is before the range with location", testCase{
+		location:    "America/Indiana/Indianapolis",
+		start:       "1:00 PM",
+		stop:        "3:00 PM",
+		now:         "4:05 PM +0000",
+		start_after: "2017-12-31T00:00:00",
+		result:      false,
+		latest:      expectedTime{isZero: true},
+	}),
+	Entry("start_after is in the past, now is after the range with location", testCase{
+		location:    "America/Indiana/Indianapolis",
+		start:       "1:00 PM",
+		stop:        "3:00 PM",
+		now:         "10:05 PM +0000",
+		start_after: "2017-12-31T00:00:00",
+		result:      false,
+		latest:      expectedTime{isZero: true},
 	}),
 )

--- a/lord/time_lord_test.go
+++ b/lord/time_lord_test.go
@@ -62,10 +62,10 @@ func (tc testCase) Run() {
 	}
 
 	if tc.start_after != "" {
-		startTime, err := time.Parse(iso8601Format, tc.start_after)
+		startAfter, err := time.Parse(iso8601Format, tc.start_after)
 		Expect(err).NotTo(HaveOccurred())
-		startTimeModel := models.StartAfter(startTime.UTC())
-		tl.StartAfter = &startTimeModel
+		startAfterModel := models.StartAfter(startAfter.UTC())
+		tl.StartAfter = &startAfterModel
 	}
 
 	if tc.start != "" {


### PR DESCRIPTION
This pull request introduces support for the `start_after` field, allowing resource version generation to be restricted to occur only on/after a specified date and time.

Changes:
- Added `start_after` functionality to ensure that versions are only generated after the given date/time.
- When the `start_after` date/time is in the past, version generation will continue as usual based on other settings.
- If `initial_version` is set to true, the first version will be based on the current time, and subsequent versions will only be created after the `start_after` date/time.
- If a `location` is specified, the `start_after` date/time is interpreted in the context of that timezone, rather than in UTC.

closes #29 