### PR TITLE
Multi-architecture support for Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,31 @@
-ARG base_image=ubuntu:latest
-ARG builder_image=concourse/golang-builder
+ARG base_image=cgr.dev/chainguard/wolfi-base
+ARG builder_image=cgr.dev/chainguard/go
 
-FROM ${builder_image} AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG GOAMD64=v3
+ARG GOARM64=v8.2
+
+FROM --platform=$BUILDPLATFORM ${builder_image} AS builder
 WORKDIR /concourse/time-resource
-COPY go.mod .
-COPY go.sum .
+COPY go.mod go.sum ./
 RUN go mod download
-COPY . /concourse/time-resource
-ENV CGO_ENABLED 0
-RUN go build -o /assets/out github.com/concourse/time-resource/out
-RUN go build -o /assets/in github.com/concourse/time-resource/in
-RUN go build -o /assets/check github.com/concourse/time-resource/check
+COPY . .
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=${GOAMD64} GOARM64=${GOARM64} go build -o /assets/out github.com/concourse/time-resource/out
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=${GOAMD64} GOARM64=${GOARM64} go build -o /assets/in github.com/concourse/time-resource/in
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOAMD64=${GOAMD64} GOARM64=${GOARM64} go build -o /assets/check github.com/concourse/time-resource/check
+
 RUN set -e; for pkg in $(go list ./...); do \
-	go test -o "/tests/$(basename $pkg).test" -c $pkg; \
+	  go test -o "/tests/$(basename $pkg).test" -c $pkg; \
 	done
 
 FROM ${base_image} AS resource
-USER root
 COPY --from=builder /assets /opt/resource
 
 FROM resource AS tests
 COPY --from=builder /tests /tests
 RUN set -e; for test in /tests/*.test; do \
-	$test; \
-	done
+      $test; \
+    done
 
 FROM resource


### PR DESCRIPTION
Optimized the Dockerfile to support multi-architecture builds using Docker BuildX. Key changes:
- Added TARGETOS and TARGETARCH arguments for cross-compilation
- Set builder to use BUILDPLATFORM for faster builds, avoiding emulation
- Configured Go builds with explicit GOOS/GOARCH for target platforms
- Maintained test execution in the appropriate target environment

This enables building the time-resource container for multiple architectures (amd64, arm64) from a single build pipeline.